### PR TITLE
bump cmb2 | phpunit

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -110,7 +110,6 @@ tools:
         enabled:                 true
         extensions:
             - php
-        command:                 php-cs-fixer
         config:
             level:               all
         filter:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 7.0
   - hhvm
   - nightly
-  - hhvm-nightly
 
 env:
   global:
@@ -26,7 +25,6 @@ matrix:
     - php: 7.0
     - php: nightly
     - php: hhvm
-    - php: hhvm-nightly
   fast_finish: true
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "php"                                                  : ">=5.4.0",
         "jjgrainger/wp-custom-post-type-class"                 : "~1.3.1",
         "wpackagist-plugin/timber-library"                     : "0.21.8",
-        "wpackagist-plugin/cmb2"                               : "~2.0.9",
+        "wpackagist-plugin/cmb2"                               : "~2.1.0",
         "gwa/mockery-wp-bridge"                                : "~1.1.0",
         "roots/soil"                                           : "3.4.0"
     },
     "require-dev": {
         "fabpot/php-cs-fixer"                                  : "~1.10",
-        "phpunit/phpunit"                                      : "~4.7",
+        "phpunit/phpunit"                                      : "~4.8",
         "scrutinizer/ocular"                                   : "~1.1"
     },
     "autoload": {

--- a/src/Theme/ThemeSettings.php
+++ b/src/Theme/ThemeSettings.php
@@ -242,7 +242,7 @@ class ThemeSettings extends TimberSite
     {
         global $wp_version;
 
-        if (version_compare($wp_version, '4.1.0', '<')) {
+        if (version_compare($wp_version, '4.2.1', '<')) {
             throw new \Exception('Your Wordpress version is too old, please upgrade to a newer version');
         }
 

--- a/src/Theme/ThemeSettings.php
+++ b/src/Theme/ThemeSettings.php
@@ -238,7 +238,7 @@ class ThemeSettings extends TimberSite
     /**
      * Init
      */
-    public function init()
+    public function run()
     {
         global $wp_version;
 


### PR DESCRIPTION
update require wordpress version to 4.2.1
rename init to run
